### PR TITLE
Add ssh cert support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 SimpleSSH is a simple wrapper around go ssh and sftp libraries.
 
 ## Features
-* Multiple authentication methods (password, private key and ssh-agent)
+* Multiple authentication methods (password, private key, certificate and ssh-agent)
 * Sudo support
 * Simple file upload/download support
 


### PR DESCRIPTION
Using SSH Certificates with simplessh

It is getting more popular to use certificates for ssh authentication, which i have added to simplessh.

In short, we need to parse the user’s private key and the certificate, create a signer using both the certificate and the private key, and use that as an auth method.

In order to keep this PR as small as possible, i have not added support for passphrases etc, but will follow in a separate PR