### PR TITLE
Allow support for diffie-hellman-group1-sha1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 [![GoDoc](https://godoc.org/github.com/sfreiberg/simplessh?status.png)](https://godoc.org/github.com/sfreiberg/simplessh)
 
 SimpleSSH is a simple wrapper around go ssh and sftp libraries.
+Altered to add support for `diffie-hellman-group1-sha1` and `diffie-hellman-group14-sha1`.
+
+[RFC 4253](https://www.rfc-editor.org/rfc/rfc4253)
+```
+8.1.  diffie-hellman-group1-sha1
+
+   The "diffie-hellman-group1-sha1" method specifies the Diffie-Hellman
+   key exchange with SHA-1 as HASH, and Oakley Group 2 [RFC2409] (1024-
+   bit MODP Group).  This method MUST be supported for interoperability
+   as all of the known implementations currently support it.  Note that
+   this method is named using the phrase "group1", even though it
+   specifies the use of Oakley Group 2.
+
+8.2.  diffie-hellman-group14-sha1
+
+   The "diffie-hellman-group14-sha1" method specifies a Diffie-Hellman
+   key exchange with SHA-1 as HASH and Oakley Group 14 [RFC3526] (2048-
+   bit MODP Group), and it MUST also be supported.
+```
 
 ## Features
 * Multiple authentication methods (password, private key and ssh-agent)

--- a/README.md
+++ b/README.md
@@ -2,25 +2,6 @@
 [![GoDoc](https://godoc.org/github.com/sfreiberg/simplessh?status.png)](https://godoc.org/github.com/sfreiberg/simplessh)
 
 SimpleSSH is a simple wrapper around go ssh and sftp libraries.
-Altered to add support for `diffie-hellman-group1-sha1` and `diffie-hellman-group14-sha1`.
-
-[RFC 4253](https://www.rfc-editor.org/rfc/rfc4253)
-```
-8.1.  diffie-hellman-group1-sha1
-
-   The "diffie-hellman-group1-sha1" method specifies the Diffie-Hellman
-   key exchange with SHA-1 as HASH, and Oakley Group 2 [RFC2409] (1024-
-   bit MODP Group).  This method MUST be supported for interoperability
-   as all of the known implementations currently support it.  Note that
-   this method is named using the phrase "group1", even though it
-   specifies the use of Oakley Group 2.
-
-8.2.  diffie-hellman-group14-sha1
-
-   The "diffie-hellman-group14-sha1" method specifies a Diffie-Hellman
-   key exchange with SHA-1 as HASH and Oakley Group 14 [RFC3526] (2048-
-   bit MODP Group), and it MUST also be supported.
-```
 
 ## Features
 * Multiple authentication methods (password, private key and ssh-agent)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/scaredos/simplessh-unsecure
+module github.com/scaredos/simplessh
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sfreiberg/simplessh
+module github.com/scaredos/simplessh-unsecure
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sfreiberg/simplessh
+module github.com/scaredos/simplessh
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/scaredos/simplessh
+module github.com/sfreiberg/simplessh
 
 go 1.18
 

--- a/simplessh.go
+++ b/simplessh.go
@@ -234,6 +234,30 @@ func connect(username, host string, authMethod ssh.AuthMethod, timeout time.Dura
 	return c, nil
 }
 
+// Execute an array of commands within the same shell and return stderr and stdout
+func (c *Client) ExecMulti(cmd []string) (string, error) {
+	session, err := c.SSHClient.NewSession()
+	if err != nil {
+		return nil, err
+	}
+	
+	defer session.Close()
+	
+	w, err := session.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	
+	var stdoutBuf bytes.Buffer
+	session.Stdout = &stdoutBuf
+	
+	err = session.Shell()
+	for i, _ := range cmd {
+		w.Write([]byte(fmt.Sprintf("%s\n", cmd[i]))
+	}
+	return stdoutBuf.String(), nil
+}
+
 // Execute cmd on the remote host and return stderr and stdout
 func (c *Client) Exec(cmd string) ([]byte, error) {
 	session, err := c.SSHClient.NewSession()

--- a/simplessh.go
+++ b/simplessh.go
@@ -248,14 +248,17 @@ func (c *Client) ExecMulti(cmd []string) (string, error) {
 		return "error", err
 	}
 	
-	var stdoutBuf bytes.Buffer
-	session.Stdout = &stdoutBuf
+	stdout, err := session.StdoutPipe()
+	if err != nil {
+		return "error", nil
+	}
 	
 	err = session.Shell()
 	for i, _ := range cmd {
 		w.Write([]byte(fmt.Sprintf("%s\n", cmd[i])))
+		go io.Copy(os.Stdout, stdout)
 	}
-	return stdoutBuf.String(), nil
+	return "done", nil
 }
 
 // Execute cmd on the remote host and return stderr and stdout

--- a/simplessh.go
+++ b/simplessh.go
@@ -198,8 +198,6 @@ func connect(username, host string, authMethod ssh.AuthMethod, timeout time.Dura
 			ssh.KeyAlgoSKED25519,
 			ssh.KeyAlgoRSASHA256,
 			ssh.KeyAlgoRSASHA512,
-			ssh.KeyAlgoDH1SHA1,
-			ssh.KeyAlgoDH14SHA1,
 
 			ssh.CertAlgoRSAv01,
 			ssh.CertAlgoDSAv01,

--- a/simplessh.go
+++ b/simplessh.go
@@ -174,6 +174,11 @@ func connect(username, host string, authMethod ssh.AuthMethod, timeout time.Dura
 			"chacha20-poly1305@openssh.com",
 		},
 		KeyExchanges: []string{
+			"curve25519-sha256",
+			"curve25519-sha256@libssh.org",
+			"diffie-hellman-group-exchange-sha1",
+			"diffie-hellman-group-exchange-sha256",
+			"diffie-hellman-group14-sha256",
 			"diffie-hellman-group1-sha1",
 			"diffie-hellman-group14-sha1",
 			"diffie-hellman-group-sha256",

--- a/simplessh.go
+++ b/simplessh.go
@@ -191,6 +191,8 @@ func connect(username, host string, authMethod ssh.AuthMethod, timeout time.Dura
 			ssh.KeyAlgoSKED25519,
 			ssh.KeyAlgoRSASHA256,
 			ssh.KeyAlgoRSASHA512,
+			ssh.KeyAlgoDH1SHA1,
+			ssh.KeyAlgoDH14SHA1,
 
 			ssh.CertAlgoRSAv01,
 			ssh.CertAlgoDSAv01,

--- a/simplessh.go
+++ b/simplessh.go
@@ -253,7 +253,7 @@ func (c *Client) ExecMulti(cmd []string) (string, error) {
 	
 	err = session.Shell()
 	for i, _ := range cmd {
-		w.Write([]byte(fmt.Sprintf("%s\n", cmd[i]))
+		w.Write([]byte(fmt.Sprintf("%s\n", cmd[i])))
 	}
 	return stdoutBuf.String(), nil
 }

--- a/simplessh.go
+++ b/simplessh.go
@@ -164,10 +164,12 @@ func connect(username, host string, authMethod ssh.AuthMethod, timeout time.Dura
 			"arcfour256",
 			"arcfour",
 			"aes128-ctr",
+			"aes128-cbc", // Cisco
 			"aes192-ctr",
+			"aes192-cbc", // Cisco
 			"aes256-ctr",
-			"aes128-cbc",
-			"3des-cbc",
+			"aes256-cbc", // Cisco
+			"3des-cbc", // Cisco
 			"des-cbc",
 
 			"aes128-gcm@openssh.com",

--- a/simplessh.go
+++ b/simplessh.go
@@ -173,6 +173,13 @@ func connect(username, host string, authMethod ssh.AuthMethod, timeout time.Dura
 			"aes128-gcm@openssh.com",
 			"chacha20-poly1305@openssh.com",
 		},
+		KeyExchanges: []string{
+			"diffie-hellman-group1-sha1",
+			"diffie-hellman-group14-sha1",
+			"diffie-hellman-group-sha256",
+			"rsa-sha2-512",
+			"rsa-sha2-256",
+			"ssh-rsa",
 	}
 
 	config := &ssh.ClientConfig{

--- a/simplessh.go
+++ b/simplessh.go
@@ -255,10 +255,11 @@ func (c *Client) ExecMulti(cmd []string) (string, error) {
 	
 	err = session.Shell()
 	for i, _ := range cmd {
+		// go io.Copy(w, fmt.Sprintf("%s\n", cmd[i]))
 		w.Write([]byte(fmt.Sprintf("%s\n", cmd[i])))
 		go io.Copy(os.Stdout, stdout)
 	}
-	return "done", nil
+	return "finished executing multiple commands", nil
 }
 
 // Execute cmd on the remote host and return stderr and stdout

--- a/simplessh.go
+++ b/simplessh.go
@@ -180,6 +180,7 @@ func connect(username, host string, authMethod ssh.AuthMethod, timeout time.Dura
 			"rsa-sha2-512",
 			"rsa-sha2-256",
 			"ssh-rsa",
+		},
 	}
 
 	config := &ssh.ClientConfig{

--- a/simplessh.go
+++ b/simplessh.go
@@ -238,14 +238,14 @@ func connect(username, host string, authMethod ssh.AuthMethod, timeout time.Dura
 func (c *Client) ExecMulti(cmd []string) (string, error) {
 	session, err := c.SSHClient.NewSession()
 	if err != nil {
-		return nil, err
+		return "error", err
 	}
 	
 	defer session.Close()
 	
 	w, err := session.StdinPipe()
 	if err != nil {
-		return nil, err
+		return "error", err
 	}
 	
 	var stdoutBuf bytes.Buffer


### PR DESCRIPTION
As per [RFC 4253](https://www.ietf.org/rfc/rfc4253.txt)

`diffie-hellman-group1-sha1` and `diffie-hellman-group14-sha1` should be supported. Along with this, other Key Exchanges should be added for support as well. 